### PR TITLE
Add `utf8_convert_to_latin1` tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 list(APPEND tests
+  utf8/latin1-convert
   utf8/utf16-convert
   utf8/utf16-length
   utf8/validate

--- a/test/utf8/latin1-convert.c
+++ b/test/utf8/latin1-convert.c
@@ -1,0 +1,26 @@
+#include <assert.h>
+#include <string.h>
+
+#include "../../include/utf.h"
+
+#define test_convert(string, len, expected, written) \
+  { \
+    latin1_t result[written]; \
+    assert(utf8_convert_to_latin1((utf8_t *) string, len, result) == written); \
+    assert(memcmp(expected, result, written) == 0); \
+  }
+
+int
+main() {
+  // ASCII character 'A'
+  test_convert("\x41", 1, "\x41", 1);
+
+  // ø Character
+  test_convert("\xc3\xb8", 2, "\xf8", 1);
+
+  // Cyrillic letter 'Д'
+  test_convert("\xd0\x94", 2, "\x3f", 1);
+
+  // Mix of Cyrillic and ø
+  test_convert("\xd0\x94\xc3\xb8", 2, "\x3f\xf8", 2);
+}

--- a/test/utf8/latin1-convert.c
+++ b/test/utf8/latin1-convert.c
@@ -18,9 +18,6 @@ main() {
   // ø Character
   test_convert("\xc3\xb8", 2, "\xf8", 1);
 
-  // Cyrillic letter 'Д'
-  test_convert("\xd0\x94", 2, "\x3f", 1);
-
-  // Mix of Cyrillic and ø
-  test_convert("\xd0\x94\xc3\xb8", 2, "\x3f\xf8", 2);
+  // Ending with an invalid character 'AAAД'
+  test_convert("\x41\x41\x41\xd0\x94", 4, "", 0);
 }


### PR DESCRIPTION
The tests that contains the Cyrillic letter fails as the return value (the written value) of `utf8_convert_to_latin1` is zero.

The static values from the tests (e.g. `\xd0\x94`) are based on the results of`Buffer.transcode` from Node.js:

```js
$ node

> { transcode } = require('node:buffer')

> transcode(Buffer.from('ø'), 'utf8', 'latin1')
<Buffer f8>

> transcode(Buffer.from('Д'), 'utf8', 'latin1')
<Buffer 3f>

> transcode(Buffer.from('Дø'), 'utf8', 'latin1')
<Buffer 3f f8>
```

The tests from this PR are a gist to help confirm there's an actual issue.